### PR TITLE
fix: don't throw when project-id for project-platform-configuration does not exist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,6 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Run Build and Test using Nuke
       run: ./build.ps1 -Target Test -Configuration Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,6 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Run Publish using Nuke
       run: ./build.ps1 -Target Publish -Configuration Release --nuget_api_key ${{ secrets.NUGET_API_KEY }}

--- a/build/SlnParser.Build.csproj
+++ b/build/SlnParser.Build.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <RootNamespace></RootNamespace>
         <NoWarn>CS0649;CS0169</NoWarn>
         <NukeRootDirectory>..</NukeRootDirectory>
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nuke.Common" Version="5.3.0"/>
-        <PackageDownload Include="GitVersion.CommandLine" Version="[5.5.1]"></PackageDownload>
+        <PackageReference Include="Nuke.Common" Version="5.3.0" />
+        <PackageDownload Include="GitVersion.CommandLine" Version="[5.5.1]" />
     </ItemGroup>
 
 </Project>

--- a/src/SlnParser.Tests/SlnParser.Tests.csproj
+++ b/src/SlnParser.Tests/SlnParser.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/SlnParser.Tests/Solutions/TestSln.sln
+++ b/src/SlnParser.Tests/Solutions/TestSln.sln
@@ -118,5 +118,6 @@ Global
 		{20AD21B6-0ABB-4DB5-8BA0-D9896E58E3E4}.Release|x64.Build.0 = Release|Any CPU
 		{20AD21B6-0ABB-4DB5-8BA0-D9896E58E3E4}.Release|x86.ActiveCfg = Release|Any CPU
 		{20AD21B6-0ABB-4DB5-8BA0-D9896E58E3E4}.Release|x86.Build.0 = Release|Any CPU
+		{2FD6FF99-971A-470A-BB0D-CE738AB29D6C}.Debug|x64.ActiveCfg = Debug|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/SlnParser/Contracts/Helper/NestedProjectMapping.cs
+++ b/src/SlnParser/Contracts/Helper/NestedProjectMapping.cs
@@ -12,8 +12,8 @@ namespace SlnParser.Contracts.Helper
             DestinationId = new Guid(destinationId);
         }
 
-        public Guid TargetId { get; set; }
+        public Guid TargetId { get; }
 
-        public Guid DestinationId { get; set; }
+        public Guid DestinationId { get; }
     }
 }

--- a/src/SlnParser/Helper/EnrichSolutionWithProjectConfigurationPlatforms.cs
+++ b/src/SlnParser/Helper/EnrichSolutionWithProjectConfigurationPlatforms.cs
@@ -24,7 +24,7 @@ namespace SlnParser.Helper
         }
 
         private static void MapConfigurationPlatformsToProjects(
-            Solution solution,
+            ISolution solution,
             IEnumerable<ProjectConfigurationPlatform> projectConfigurations)
         {
             foreach (var configuration in projectConfigurations)
@@ -32,7 +32,7 @@ namespace SlnParser.Helper
         }
 
         private static void MapConfigurationPlatformToProject(
-            Solution solution,
+            ISolution solution,
             ProjectConfigurationPlatform configuration)
         {
             if (!configuration.ProjectId.HasValue)
@@ -44,11 +44,7 @@ namespace SlnParser.Helper
                 .AllProjects
                 .FirstOrDefault(project => project.Id == configuration.ProjectId.Value);
 
-            if (project == null)
-                throw new UnexpectedSolutionStructureException(
-                    "Expected to find a project with the id " +
-                    $"'{configuration.ProjectId.Value}' for the Project-Platform-Configuration " +
-                    $"'{configuration.ConfigurationPlatform.Name}'");
+            if (project == null) return;
 
             if (!(project is SolutionProject solutionProject))
                 throw new UnexpectedSolutionStructureException(

--- a/src/SlnParser/Helper/EnrichSolutionWithSolutionFolderFiles.cs
+++ b/src/SlnParser/Helper/EnrichSolutionWithSolutionFolderFiles.cs
@@ -89,7 +89,7 @@ namespace SlnParser.Helper
             _inASolutionItemsSection = line.StartsWith("ProjectSection(SolutionItems)");
         }
 
-        private void AddSolutionItemFile(Solution solution, string line)
+        private void AddSolutionItemFile(ISolution solution, string line)
         {
             if (!_inASolutionItemsSection) return;
 
@@ -100,7 +100,7 @@ namespace SlnParser.Helper
         }
 
         private static bool TryGetSolutionItemFile(
-            Solution solution,
+            ISolution solution,
             string line,
             out FileInfo solutionItemFile)
         {


### PR DESCRIPTION
## 📫 Addressed Issue(s)

- none

## 📄 Description

the `SlnParser` currently throws an `UnexpectedSolutionStructureException` when a project-id for a project-platform-configuration entry does not exist. This does not seem to be an issue for any editor and is totally fine.  
Because of that, this should not throw an exception when parsing a solution

## ✅ Checks

- [x] My PR adheres to the general code-style of this project (look at other code if you're unsure)
- ~[ ] My code requires changes to the documentation~
- ~[ ] I have updated the documentation as required~
- [x] All the automated tests have passed
